### PR TITLE
Fixed 'attempt to negate with overflow' exception.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 **/*.rs.bk
 /config
 /.idea

--- a/server/src/light/mod.rs
+++ b/server/src/light/mod.rs
@@ -13,13 +13,13 @@ pub struct HighestOpaqueBlock {
 impl HighestOpaqueBlock {
     pub fn new() -> Self {
         Self {
-            y: [-i64::min_value(); (CHUNK_SIZE * CHUNK_SIZE) as usize],
+            y: [i64::MIN; (CHUNK_SIZE * CHUNK_SIZE) as usize],
         }
     }
 
     pub fn from_chunk(chunk: &Arc<Chunk>) -> Self {
         let mut hob = Self {
-            y: [-i64::min_value(); (CHUNK_SIZE * CHUNK_SIZE) as usize],
+            y: [i64::MIN; (CHUNK_SIZE * CHUNK_SIZE) as usize],
         };
         for i in 0..CHUNK_SIZE {
             for k in 0..CHUNK_SIZE {


### PR DESCRIPTION
I was receiving this on startup, seems it was related to negating a negative (i64::MIN) number. This PR fixes the issue.
```
thread '<unnamed>' panicked at 'attempt to negate with overflow', server/src/light/mod.rs:16:17
stack backtrace:
   0: rust_begin_unwind
             at /build/rust/src/rustc-1.48.0-src/library/std/src/panicking.rs:483
   1: core::panicking::panic_fmt
             at /build/rust/src/rustc-1.48.0-src/library/core/src/panicking.rs:85
   2: core::panicking::panic
             at /build/rust/src/rustc-1.48.0-src/library/core/src/panicking.rs:50
   3: voxel_rs_server::light::HighestOpaqueBlock::new
             at ./server/src/light/mod.rs:16
   4: voxel_rs_server::world::World::set_chunk::{{closure}}
             at ./server/src/world.rs:133
   5: std::collections::hash::map::Entry<K,V>::or_insert_with
             at /build/rust/src/rustc-1.48.0-src/library/std/src/collections/hash/map.rs:2221
   6: voxel_rs_server::world::World::set_chunk
             at ./server/src/world.rs:131
   7: voxel_rs_server::world::World::get_new_generated_chunks
             at ./server/src/world.rs:150
   8: voxel_rs_server::launch_server
             at ./server/src/lib.rs:193
   9: voxel_rs_client::main::{{closure}}
             at ./client/./src/main.rs:31
```